### PR TITLE
Issue17

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,11 @@ services:
       DB_USER: appuser
       DB_PASSWORD: secret
       DB_NAME: microservice_db
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8083/healthz"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
 
   orderservice:
     build: ./orderservice
@@ -39,13 +44,20 @@ services:
       postgres:
         condition: service_healthy
       productservice:
-        condition: service_started
+        condition: service_healthy
+      userservice:
+        condition: service_healthy
     environment:
       DB_HOST: postgres
       DB_PORT: 5432
       DB_USER: appuser
       DB_PASSWORD: secret
       DB_NAME: microservice_db
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8082/healthz"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
 
   productservice:
     build: ./productservice
@@ -60,15 +72,28 @@ services:
       DB_USER: appuser
       DB_PASSWORD: secret
       DB_NAME: microservice_db
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8081/healthz"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
 
   gateway:
     build: ./gateway
     ports:
       - "8080:8080"
     depends_on:
-      - userservice
-      - orderservice
-      - productservice
+      userservice:
+        condition: service_healthy
+      orderservice:
+        condition: service_healthy
+      productservice:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/healthz"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
 
   frontendservice:
     build: ./frontendservice
@@ -76,7 +101,13 @@ services:
       # Host port 3001 to avoid colliding with other local containers on 3000
       - "3001:3000"
     depends_on:
-      - gateway
+      gateway:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000/healthz"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
 
 volumes:
   postgres_data:

--- a/frontendservice/main.go
+++ b/frontendservice/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"time"
 )
 
 func main() {
@@ -174,5 +175,10 @@ func main() {
 	})
 
 	log.Println("Frontend service running on :3000")
-	log.Fatal(http.ListenAndServe(":3000", nil))
+	server := &http.Server{
+		Addr:         ":3000",
+		ReadTimeout:  5 * time.Second,
+		WriteTimeout: 10 * time.Second,
+	}
+	log.Fatal(server.ListenAndServe())
 }

--- a/frontendservice/main.go
+++ b/frontendservice/main.go
@@ -7,6 +7,11 @@ import (
 )
 
 func main() {
+	http.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok"))
+	})
+
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/html")
 

--- a/frontendservice/main.go
+++ b/frontendservice/main.go
@@ -1,9 +1,13 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
 	"time"
 )
 
@@ -180,5 +184,27 @@ func main() {
 		ReadTimeout:  5 * time.Second,
 		WriteTimeout: 10 * time.Second,
 	}
-	log.Fatal(server.ListenAndServe())
+	runWithGracefulShutdown(server)
+}
+
+// runWithGracefulShutdown serves until SIGTERM/SIGINT, then gives in-flight
+// requests up to 10s to finish so deploys don't cut anyone off mid-request.
+func runWithGracefulShutdown(server *http.Server) {
+	go func() {
+		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Fatal(err)
+		}
+	}()
+
+	stop := make(chan os.Signal, 1)
+	signal.Notify(stop, syscall.SIGTERM, syscall.SIGINT)
+	<-stop
+
+	log.Println("shutting down: waiting for in-flight requests")
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := server.Shutdown(ctx); err != nil {
+		log.Fatal("forced shutdown:", err)
+	}
+	log.Println("shutdown complete")
 }

--- a/gateway/main.go
+++ b/gateway/main.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"os"
+	"time"
 )
 
 // envOr returns the env value for key, or fallback when unset;
@@ -62,5 +63,14 @@ func main() {
 	http.HandleFunc("/users/", proxyHandler(userURL))
 
 	log.Println("API Gateway listening on port 8080")
-	log.Fatal(http.ListenAndServe(":8080", nil))
+	// WriteTimeout is generous because the gateway waits on downstream
+	// services: an order creation can legitimately take several seconds
+	// while orderservice calls its neighbors. An upstream's patience must
+	// exceed its downstreams' worst case.
+	server := &http.Server{
+		Addr:         ":8080",
+		ReadTimeout:  5 * time.Second,
+		WriteTimeout: 30 * time.Second,
+	}
+	log.Fatal(server.ListenAndServe())
 }

--- a/gateway/main.go
+++ b/gateway/main.go
@@ -38,11 +38,20 @@ func proxyHandler(target string) http.HandlerFunc {
 	}
 }
 
+// healthzHandler: the gateway has no dependencies of its own to check
+// (a backend being down is that backend's problem, reported per-request
+// as 502), so healthy just means alive and serving.
+func healthzHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("ok"))
+}
+
 func main() {
 	productURL := envOr("PRODUCT_SERVICE_URL", "http://productservice:8081")
 	orderURL := envOr("ORDER_SERVICE_URL", "http://orderservice:8082")
 	userURL := envOr("USER_SERVICE_URL", "http://userservice:8083")
 
+	http.HandleFunc("/healthz", healthzHandler)
 	http.HandleFunc("/products", proxyHandler(productURL))
 	http.HandleFunc("/products/", proxyHandler(productURL))
 

--- a/gateway/main.go
+++ b/gateway/main.go
@@ -1,11 +1,14 @@
 package main
 
 import (
+	"context"
 	"log"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
 	"os"
+	"os/signal"
+	"syscall"
 	"time"
 )
 
@@ -72,5 +75,27 @@ func main() {
 		ReadTimeout:  5 * time.Second,
 		WriteTimeout: 30 * time.Second,
 	}
-	log.Fatal(server.ListenAndServe())
+	runWithGracefulShutdown(server)
+}
+
+// runWithGracefulShutdown serves until SIGTERM/SIGINT, then gives in-flight
+// requests up to 10s to finish so deploys don't cut anyone off mid-request.
+func runWithGracefulShutdown(server *http.Server) {
+	go func() {
+		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Fatal(err)
+		}
+	}()
+
+	stop := make(chan os.Signal, 1)
+	signal.Notify(stop, syscall.SIGTERM, syscall.SIGINT)
+	<-stop
+
+	log.Println("shutting down: waiting for in-flight requests")
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := server.Shutdown(ctx); err != nil {
+		log.Fatal("forced shutdown:", err)
+	}
+	log.Println("shutdown complete")
 }

--- a/gateway/main_test.go
+++ b/gateway/main_test.go
@@ -84,3 +84,13 @@ func TestProxyBackendUnreachable(t *testing.T) {
 		t.Errorf("expected 502 when backend is down, got %d", rec.Code)
 	}
 }
+
+func TestHealthz(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	rec := httptest.NewRecorder()
+	healthzHandler(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rec.Code)
+	}
+}

--- a/orderservice/main.go
+++ b/orderservice/main.go
@@ -9,8 +9,10 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"os/signal"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"gorm.io/driver/postgres"
@@ -355,5 +357,27 @@ func main() {
 		ReadTimeout:  5 * time.Second,
 		WriteTimeout: 10 * time.Second,
 	}
-	log.Fatal(server.ListenAndServe())
+	runWithGracefulShutdown(server)
+}
+
+// runWithGracefulShutdown serves until SIGTERM/SIGINT, then gives in-flight
+// requests up to 10s to finish so deploys don't cut anyone off mid-request.
+func runWithGracefulShutdown(server *http.Server) {
+	go func() {
+		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Fatal(err)
+		}
+	}()
+
+	stop := make(chan os.Signal, 1)
+	signal.Notify(stop, syscall.SIGTERM, syscall.SIGINT)
+	<-stop
+
+	log.Println("shutting down: waiting for in-flight requests")
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := server.Shutdown(ctx); err != nil {
+		log.Fatal("forced shutdown:", err)
+	}
+	log.Println("shutdown complete")
 }

--- a/orderservice/main.go
+++ b/orderservice/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -10,6 +11,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
@@ -317,9 +319,28 @@ func ordersRouter(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// healthzHandler reports whether the service can do its job: alive and
+// able to reach the database. The ping gets a short deadline so a hung
+// DB connection makes the check fail instead of hang.
+func healthzHandler(w http.ResponseWriter, r *http.Request) {
+	sqlDB, err := db.DB()
+	if err == nil {
+		ctx, cancel := context.WithTimeout(r.Context(), 2*time.Second)
+		defer cancel()
+		err = sqlDB.PingContext(ctx)
+	}
+	if err != nil {
+		http.Error(w, "database unreachable", http.StatusServiceUnavailable)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("ok"))
+}
+
 func main() {
 	initDB()
 
+	http.HandleFunc("/healthz", healthzHandler)
 	http.HandleFunc("/orders", ordersRouter)
 	http.HandleFunc("/orders/", ordersRouter)
 

--- a/orderservice/main.go
+++ b/orderservice/main.go
@@ -55,6 +55,11 @@ func envOr(key, fallback string) string {
 	return fallback
 }
 
+// httpClient is used for all calls to other services. The timeout keeps a
+// hung neighbor from stalling order requests indefinitely (the default
+// http.Client waits forever).
+var httpClient = &http.Client{Timeout: 5 * time.Second}
+
 func initDB() {
 	dsn := fmt.Sprintf(
 		"host=%s user=%s password=%s dbname=%s port=%s sslmode=disable",
@@ -246,7 +251,7 @@ func updateOrderHandler(w http.ResponseWriter, r *http.Request) {
 func getProduct(productID int) (Product, error) {
 	url := fmt.Sprintf("%s/products/%d", productServiceURL, productID)
 
-	resp, err := http.Get(url)
+	resp, err := httpClient.Get(url)
 	if err != nil {
 		return Product{}, fmt.Errorf("error making request: %w", err)
 	}
@@ -273,7 +278,7 @@ func getProduct(productID int) (Product, error) {
 func getUser(userID int) (User, error) {
 	url := fmt.Sprintf("%s/users/%d", userServiceURL, userID)
 
-	resp, err := http.Get(url)
+	resp, err := httpClient.Get(url)
 	if err != nil {
 		return User{}, fmt.Errorf("error calling user service: %w", err)
 	}
@@ -345,7 +350,10 @@ func main() {
 	http.HandleFunc("/orders/", ordersRouter)
 
 	log.Println("Order Service listening on port 8082")
-	if err := http.ListenAndServe(":8082", nil); err != nil {
-		log.Fatal(err)
+	server := &http.Server{
+		Addr:         ":8082",
+		ReadTimeout:  5 * time.Second,
+		WriteTimeout: 10 * time.Second,
 	}
+	log.Fatal(server.ListenAndServe())
 }

--- a/orderservice/main_test.go
+++ b/orderservice/main_test.go
@@ -269,3 +269,34 @@ func TestOrdersRouterMethodNotAllowed(t *testing.T) {
 		t.Errorf("expected 405, got %d", rec.Code)
 	}
 }
+
+func TestHealthz(t *testing.T) {
+	setupTestDB(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	rec := httptest.NewRecorder()
+	healthzHandler(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rec.Code)
+	}
+}
+
+func TestHealthzDatabaseDown(t *testing.T) {
+	setupTestDB(t)
+
+	// Close the underlying connection to simulate an unreachable database.
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatalf("failed to get sql.DB: %v", err)
+	}
+	sqlDB.Close()
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	rec := httptest.NewRecorder()
+	healthzHandler(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected 503, got %d", rec.Code)
+	}
+}

--- a/productservice/main.go
+++ b/productservice/main.go
@@ -8,8 +8,10 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"os/signal"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"gorm.io/driver/postgres"
@@ -157,5 +159,27 @@ func main() {
 		ReadTimeout:  5 * time.Second,
 		WriteTimeout: 10 * time.Second,
 	}
-	log.Fatal(server.ListenAndServe())
+	runWithGracefulShutdown(server)
+}
+
+// runWithGracefulShutdown serves until SIGTERM/SIGINT, then gives in-flight
+// requests up to 10s to finish so deploys don't cut anyone off mid-request.
+func runWithGracefulShutdown(server *http.Server) {
+	go func() {
+		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Fatal(err)
+		}
+	}()
+
+	stop := make(chan os.Signal, 1)
+	signal.Notify(stop, syscall.SIGTERM, syscall.SIGINT)
+	<-stop
+
+	log.Println("shutting down: waiting for in-flight requests")
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := server.Shutdown(ctx); err != nil {
+		log.Fatal("forced shutdown:", err)
+	}
+	log.Println("shutdown complete")
 }

--- a/productservice/main.go
+++ b/productservice/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -9,6 +10,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
@@ -115,9 +117,28 @@ func createProductHandler(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(product)
 }
 
+// healthzHandler reports whether the service can do its job: alive and
+// able to reach the database. The ping gets a short deadline so a hung
+// DB connection makes the check fail instead of hang.
+func healthzHandler(w http.ResponseWriter, r *http.Request) {
+	sqlDB, err := db.DB()
+	if err == nil {
+		ctx, cancel := context.WithTimeout(r.Context(), 2*time.Second)
+		defer cancel()
+		err = sqlDB.PingContext(ctx)
+	}
+	if err != nil {
+		http.Error(w, "database unreachable", http.StatusServiceUnavailable)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("ok"))
+}
+
 func main() {
 	initDB()
 
+	http.HandleFunc("/healthz", healthzHandler)
 	http.HandleFunc("/products", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodGet {
 			getProductsHandler(w, r)

--- a/productservice/main.go
+++ b/productservice/main.go
@@ -152,5 +152,10 @@ func main() {
 	http.HandleFunc("/products/", getProductHandler)
 
 	log.Println("Product Service listening on port 8081")
-	log.Fatal(http.ListenAndServe(":8081", nil))
+	server := &http.Server{
+		Addr:         ":8081",
+		ReadTimeout:  5 * time.Second,
+		WriteTimeout: 10 * time.Second,
+	}
+	log.Fatal(server.ListenAndServe())
 }

--- a/productservice/main_test.go
+++ b/productservice/main_test.go
@@ -146,3 +146,34 @@ func TestCreateProductInvalidJSON(t *testing.T) {
 		t.Errorf("expected 400, got %d", rec.Code)
 	}
 }
+
+func TestHealthz(t *testing.T) {
+	setupTestDB(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	rec := httptest.NewRecorder()
+	healthzHandler(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rec.Code)
+	}
+}
+
+func TestHealthzDatabaseDown(t *testing.T) {
+	setupTestDB(t)
+
+	// Close the underlying connection to simulate an unreachable database.
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatalf("failed to get sql.DB: %v", err)
+	}
+	sqlDB.Close()
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	rec := httptest.NewRecorder()
+	healthzHandler(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected 503, got %d", rec.Code)
+	}
+}

--- a/userservice/main.go
+++ b/userservice/main.go
@@ -8,8 +8,10 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"os/signal"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"gorm.io/driver/postgres"
@@ -157,5 +159,27 @@ func main() {
 		WriteTimeout: 10 * time.Second,
 	}
 	log.Println("User service running on port 8083")
-	log.Fatal(server.ListenAndServe())
+	runWithGracefulShutdown(server)
+}
+
+// runWithGracefulShutdown serves until SIGTERM/SIGINT, then gives in-flight
+// requests up to 10s to finish so deploys don't cut anyone off mid-request.
+func runWithGracefulShutdown(server *http.Server) {
+	go func() {
+		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Fatal(err)
+		}
+	}()
+
+	stop := make(chan os.Signal, 1)
+	signal.Notify(stop, syscall.SIGTERM, syscall.SIGINT)
+	<-stop
+
+	log.Println("shutting down: waiting for in-flight requests")
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := server.Shutdown(ctx); err != nil {
+		log.Fatal("forced shutdown:", err)
+	}
+	log.Println("shutdown complete")
 }

--- a/userservice/main.go
+++ b/userservice/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -9,6 +10,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
@@ -115,9 +117,28 @@ func createUserHandler(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(user)
 }
 
+// healthzHandler reports whether the service can do its job: alive and
+// able to reach the database. The ping gets a short deadline so a hung
+// DB connection makes the check fail instead of hang.
+func healthzHandler(w http.ResponseWriter, r *http.Request) {
+	sqlDB, err := db.DB()
+	if err == nil {
+		ctx, cancel := context.WithTimeout(r.Context(), 2*time.Second)
+		defer cancel()
+		err = sqlDB.PingContext(ctx)
+	}
+	if err != nil {
+		http.Error(w, "database unreachable", http.StatusServiceUnavailable)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("ok"))
+}
+
 func main() {
 	initDB()
 
+	http.HandleFunc("/healthz", healthzHandler)
 	http.HandleFunc("/users", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodGet {
 			getAllUsersHandler(w, r)

--- a/userservice/main.go
+++ b/userservice/main.go
@@ -151,6 +151,11 @@ func main() {
 
 	http.HandleFunc("/users/", getUserHandler)
 
+	server := &http.Server{
+		Addr:         ":8083",
+		ReadTimeout:  5 * time.Second,
+		WriteTimeout: 10 * time.Second,
+	}
 	log.Println("User service running on port 8083")
-	log.Fatal(http.ListenAndServe(":8083", nil))
+	log.Fatal(server.ListenAndServe())
 }

--- a/userservice/main_test.go
+++ b/userservice/main_test.go
@@ -158,3 +158,34 @@ func TestCreateUserValidation(t *testing.T) {
 		})
 	}
 }
+
+func TestHealthz(t *testing.T) {
+	setupTestDB(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	rec := httptest.NewRecorder()
+	healthzHandler(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rec.Code)
+	}
+}
+
+func TestHealthzDatabaseDown(t *testing.T) {
+	setupTestDB(t)
+
+	// Close the underlying connection to simulate an unreachable database.
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatalf("failed to get sql.DB: %v", err)
+	}
+	sqlDB.Close()
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	rec := httptest.NewRecorder()
+	healthzHandler(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected 503, got %d", rec.Code)
+	}
+}


### PR DESCRIPTION
### Summary of Changes

Clean up for all five services: how they start, struggle, and stop.

- **Health endpoints:** `/healthz` on every service; the DB-backed ones ping Postgres with a 2s deadline and report 503 when it's unreachable
- **Timeouts:** server read/write timeouts everywhere (gateway gets a larger write timeout since it waits on downstream), plus a 5s client timeout on orderservice's inter-service calls so a hung neighbor fails an order in seconds instead of stalling it forever
- **Graceful shutdown:** services catch SIGTERM, give in-flight requests up to 10s to finish, and exit 0 
- **Tests:** 7 new (39 total), including the 503-when-database-down paths
- **Compose wiring:** healthchecks on every service hit `/healthz`; `depends_on` upgraded from "started" to `service_healthy` across the chain, so the stack starts in dependency order and `docker compose ps` shows real health per service

### Type of Change

- [x] New feature
- [x] Test update

### Problem Solved

Nothing could observe whether a service was actually able to do its job, a hung downstream service would stall indefinitely, and every container stop killed services mid-request (exit code 2). All three are fixed and verified. This is also the groundwork for the Kubernetes stage: probes will consume /healthz, and rolling updates depend on SIGTERM handling.

### Screenshots / GIFs (if applicable)

N/A

### Related Issues

Closes #17

### Testing Instructions

- `go test ./...` in each service directory 
- `docker compose up --build -d && sleep 15 && docker compose ps` — every service shows (healthy)
- Graceful shutdown: `docker compose stop userservice` — logs end with  "shutting down: waiting for in-flight requests" / "shutdown complete", exit code 0
- Client timeout: `docker compose pause productservice`, POST an order via the gateway — fails cleanly after 5s instead of hanging  (`docker compose unpause productservice` after)
  
  ### Checklist

- [x] Code is clean and follows project guidelines
- [x] Unit tests are added for new features
- [ ] Documentation is updated 