### PR TITLE
Issue18

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,8 +104,8 @@ curl -X DELETE localhost:8080/orders/1   # 204, or 404 if it's already gone
 
 What I'd change for production:
 
-- **One shared database.** All services use one Postgres instance with separate tables (each service only touches its own). Real isolation would mean a database per service — one instance just keeps local dev simple.
-- **Dev-only DB credentials in compose.** Fine for a throwaway local container. Production would pull these from a secrets manager; moving them to a `.env` file is on the list.
+- **One Postgres instance, isolated databases.** Each service gets its own database and login (provisioned by an init script), and revoked CONNECT privileges make cross-service data access impossible rather than just avoided — services can only reach each other's data through their APIs. Separate *instances* per service would be the next isolation level; one instance keeps local dev light and matches the eventual RDS layout.
+- **Dev-only DB credentials in compose and the init script.** Fine for a throwaway local container holding demo data. Production would pull these from a secrets manager; moving them to a `.env` file is on the list.
 - **CORS wide open (`*`)** so the demo UI works from any local origin. Would lock this to known origins for real use.
 - **`sslmode=disable` on DB connections.** Fine inside the compose network 
 - **No auth.** I'd add it at the gateway (JWT) rather than per-service.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,7 @@ services:
   postgres:
     image: postgres:15
     ports:
-      # Host port 5435 to avoid colliding with other local Postgres containers;
-      # services on the compose network still reach it at postgres:5432
+      # Host port 5435 to avoid colliding with other local Postgres containers
       - "5435:5432"
     environment:
       POSTGRES_DB: microservice_db
@@ -11,6 +10,8 @@ services:
       POSTGRES_PASSWORD: secret
     volumes:
       - postgres_data:/var/lib/postgresql/data
+      # Runs once on first init
+      - ./postgres/init.sql:/docker-entrypoint-initdb.d/init.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U appuser -d microservice_db"]
       interval: 5s
@@ -27,9 +28,9 @@ services:
     environment:
       DB_HOST: postgres
       DB_PORT: 5432
-      DB_USER: appuser
-      DB_PASSWORD: secret
-      DB_NAME: microservice_db
+      DB_USER: user_svc
+      DB_PASSWORD: user_secret
+      DB_NAME: users_db
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8083/healthz"]
       interval: 5s
@@ -50,9 +51,9 @@ services:
     environment:
       DB_HOST: postgres
       DB_PORT: 5432
-      DB_USER: appuser
-      DB_PASSWORD: secret
-      DB_NAME: microservice_db
+      DB_USER: order_svc
+      DB_PASSWORD: order_secret
+      DB_NAME: orders_db
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8082/healthz"]
       interval: 5s
@@ -69,9 +70,9 @@ services:
     environment:
       DB_HOST: postgres
       DB_PORT: 5432
-      DB_USER: appuser
-      DB_PASSWORD: secret
-      DB_NAME: microservice_db
+      DB_USER: product_svc
+      DB_PASSWORD: product_secret
+      DB_NAME: products_db
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8081/healthz"]
       interval: 5s
@@ -98,7 +99,7 @@ services:
   frontendservice:
     build: ./frontendservice
     ports:
-      # Host port 3001 to avoid colliding with other local containers on 3000
+      # Host port 3001 to avoid colliding with local containers on 3000
       - "3001:3000"
     depends_on:
       gateway:

--- a/postgres/init.sql
+++ b/postgres/init.sql
@@ -1,0 +1,15 @@
+-- Runs once on first init (docker-entrypoint-initdb.d)
+
+CREATE USER user_svc    WITH PASSWORD 'user_secret';
+CREATE USER product_svc WITH PASSWORD 'product_secret';
+CREATE USER order_svc   WITH PASSWORD 'order_secret';
+
+-- Each service has full rights in its own database
+CREATE DATABASE users_db    OWNER user_svc;
+CREATE DATABASE products_db OWNER product_svc;
+CREATE DATABASE orders_db   OWNER order_svc;
+
+-- revoke default connect so only each database's owner can connect
+REVOKE CONNECT ON DATABASE users_db    FROM PUBLIC;
+REVOKE CONNECT ON DATABASE products_db FROM PUBLIC;
+REVOKE CONNECT ON DATABASE orders_db   FROM PUBLIC;


### PR DESCRIPTION
### Summary of Changes

Database isolation: service boundaries are now enforced by Postgres.

- Init script (`postgres/init.sql`, runs once on first init) creates a database and login per service: `users_db`/`user_svc`, `products_db`/`product_svc`,`orders_db`/`order_svc`
- Default CONNECT privilege revoked from PUBLIC on all three — only each database's owner can enter it
- Compose gives each service its own credentials; no Go code changes needed
- README updated 
- 
### Type of Change

- [x] New feature
- [x] Documentation update

### Problem Solved

All services previously shared one database and one login, so nothing prevented a service from reading another's tables directly. One Postgres instance is kept deliberately (instance-per-service is the next isolation level).

### Screenshots / GIFs (if applicable)

N/A

### Related Issues

Closes #18

### Testing Instructions

- Existing checkouts: `docker compose down -v` first (the init script only runs  against a fresh data directory)
- `docker compose up --build -d && sleep 15 && docker compose ps` — all healthy
- Place an order via the gateway — works end to end across the three databases
  `docker compose exec postgres psql -U order_svc -d users_db -c "SELECT 1"`
  → FATAL: permission denied ("User does not have CONNECT privilege")
- Legitimate access still works:
  `docker compose exec postgres psql -U user_svc -d users_db -c "SELECT * FROM users"`

### Checklist

- [x] Code is clean and follows project guidelines
- [ ] Unit tests are added for new features 
- [x] Documentation is updated